### PR TITLE
Fix fields in client library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 before_install:
   - gem update --system
   - gem --version
+  - gem update bundler
 
 rvm:
   - "2.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+before_install:
+  - gem update --system
+  - gem --version
+
 rvm:
   - "2.1"
   - 2.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![](https://raw.github.com/aptible/straptible/master/lib/straptible/rails/templates/public.api/icon-60px.png) Aptible::Billing
 
-[![Gem Version](https://badge.fury.io/rb/aptible-billing-ruby.png)](https://rubygems.org/gems/aptible-billing)
+[![Gem Version](https://badge.fury.io/rb/aptible-billing.png)](https://rubygems.org/gems/aptible-billing)
 [![Build Status](https://travis-ci.org/aptible/aptible-billing-ruby.png?branch=master)](https://travis-ci.org/aptible/aptible-billing-ruby)
 [![Dependency Status](https://gemnasium.com/aptible/aptible-billing-ruby.png)](https://gemnasium.com/aptible/aptible-billing-ruby)
 

--- a/lib/aptible/billing/meter.rb
+++ b/lib/aptible/billing/meter.rb
@@ -3,22 +3,14 @@ module Aptible
     class Meter < Resource
       field :id
       field :size
-      field :organization_id
+      field :meter_type, type: String
+      field :description, type: String
+      field :account_id, type: String
       field :created_at, type: Time
       field :updated_at, type: Time
       field :started_at, type: Time
       field :ended_at, type: Time
       belongs_to :billing_detail
-
-      def organization
-        Aptible::Auth::Organization.find(
-            links['organization_id'],
-            token: token,
-            headers: headers)
-      rescue
-        nil
-      end
-
     end
   end
 end

--- a/lib/aptible/billing/version.rb
+++ b/lib/aptible/billing/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Billing
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end

--- a/spec/aptible/billing/meter_spec.rb
+++ b/spec/aptible/billing/meter_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
 
 describe Aptible::Billing::Meter do
-
 end


### PR DESCRIPTION
Use `billing_detail_id` instead of `organization_id`. Add `account_id` and `meter_type` as meter fields.

cc @fancyremarker 