### PR TITLE
Revert meter_type to be type.

### DIFF
--- a/aptible-billing-ruby.gemspec
+++ b/aptible-billing-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'stripe', '>= 1.13.0'
-  spec.add_dependency 'aptible-resource', '>= 0.2.1'
+  spec.add_dependency 'aptible-resource', '>= 0.3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'aptible-tasks'

--- a/lib/aptible/billing/meter.rb
+++ b/lib/aptible/billing/meter.rb
@@ -3,14 +3,22 @@ module Aptible
     class Meter < Resource
       field :id
       field :size
-      field :meter_type, type: String
+      field :type, type: String
       field :description, type: String
       field :account_id, type: String
       field :created_at, type: Time
       field :updated_at, type: Time
       field :started_at, type: Time
       field :ended_at, type: Time
-      belongs_to :billing_detail
+
+      def billing_detail
+        Aptible::Billing::BillingDetail.find_by_url(
+          links['billing_detail'].href,
+          token: token,
+          headers: headers)
+      rescue
+        nil
+      end
     end
   end
 end

--- a/lib/aptible/billing/version.rb
+++ b/lib/aptible/billing/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Billing
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end


### PR DESCRIPTION
This reverts the naming of the meter_type field to be type again.
Bump aptible-resource version that supports this change.

cc @fancyremarker 