### PR TITLE
Add has_many :meters to billing_detail

### DIFF
--- a/aptible-billing-ruby.gemspec
+++ b/aptible-billing-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'stripe', '>= 1.13.0'
-  spec.add_dependency 'aptible-resource', '>= 0.3.1'
+  spec.add_dependency 'aptible-resource', '>= 0.3.6'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'aptible-tasks'

--- a/lib/aptible/billing/billing_detail.rb
+++ b/lib/aptible/billing/billing_detail.rb
@@ -10,6 +10,7 @@ module Aptible
       field :stripe_subscription_id
       field :stripe_subscription_status
       field :plan
+      has_many :meters
 
       def organization
         Aptible::Auth::Organization.find_by_url(

--- a/lib/aptible/billing/meter.rb
+++ b/lib/aptible/billing/meter.rb
@@ -11,15 +11,6 @@ module Aptible
       field :started_at, type: Time
       field :ended_at, type: Time
       belongs_to :billing_detail
-
-      def billing_detail
-        Aptible::Billing::BillingDetail.find_by_url(
-          links['billing_detail'].href,
-          token: token,
-          headers: headers)
-      rescue
-        nil
-      end
     end
   end
 end

--- a/lib/aptible/billing/meter.rb
+++ b/lib/aptible/billing/meter.rb
@@ -10,6 +10,7 @@ module Aptible
       field :updated_at, type: Time
       field :started_at, type: Time
       field :ended_at, type: Time
+      belongs_to :billing_detail
 
       def billing_detail
         Aptible::Billing::BillingDetail.find_by_url(

--- a/lib/aptible/billing/version.rb
+++ b/lib/aptible/billing/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Billing
-    VERSION = '0.1.5'
+    VERSION = '0.1.6'
   end
 end


### PR DESCRIPTION
This is related to the work in aptible/billing.aptible.com#90; add a
has_many association so we can query for running meters from
api.aptible.com.