### PR TITLE
Pin ActiveSupport in Gemfile, not Gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 4.0'
+
 # Specify your gem's dependencies in aptible-billing-billing.gemspec
 gemspec

--- a/aptible-billing-ruby.gemspec
+++ b/aptible-billing-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'stripe', '>= 1.13.0'
-  spec.add_dependency 'activesupport', '~> 4.0'
+  spec.add_dependency 'activesupport', '>= 4.0', '< 6.0'
   spec.add_dependency 'aptible-resource', '~> 0.4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
We require 4.0 in test, but not in prod.